### PR TITLE
feat: add round robin provider rotation

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -156,6 +156,9 @@ export const providerSettingsEntrySchema = z.object({
 	name: z.string(),
 	apiProvider: providerNamesSchema.optional(),
 	modelId: z.string().optional(),
+	roundRobinEnabled: z.boolean().optional(),
+	roundRobinOrder: z.number().int().min(1).optional(),
+	roundRobinMessagesPerTurn: z.number().int().min(1).optional(),
 })
 
 export type ProviderSettingsEntry = z.infer<typeof providerSettingsEntrySchema>
@@ -172,6 +175,10 @@ const baseProviderSettingsSchema = z.object({
 	modelTemperature: z.number().nullish(),
 	rateLimitSeconds: z.number().optional(),
 	consecutiveMistakeLimit: z.number().min(0).optional(),
+
+	roundRobinEnabled: z.boolean().optional(),
+	roundRobinOrder: z.number().int().min(1).optional(),
+	roundRobinMessagesPerTurn: z.number().int().min(1).optional(),
 
 	// Model reasoning.
 	enableReasoningEffort: z.boolean().optional(),

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -302,6 +302,9 @@ export class ProviderSettingsManager {
 					id: apiConfig.id || "",
 					apiProvider: apiConfig.apiProvider,
 					modelId: this.cleanModelId(getModelId(apiConfig)),
+					roundRobinEnabled: apiConfig.roundRobinEnabled,
+					roundRobinOrder: apiConfig.roundRobinOrder,
+					roundRobinMessagesPerTurn: apiConfig.roundRobinMessagesPerTurn,
 				}))
 			})
 		} catch (error) {

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -5,6 +5,7 @@ import crypto from "crypto"
 import EventEmitter from "events"
 
 import { Anthropic } from "@anthropic-ai/sdk"
+import deepEqual from "fast-deep-equal"
 import delay from "delay"
 import pWaitFor from "p-wait-for"
 import { serializeError } from "serialize-error"
@@ -218,7 +219,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private pauseInterval: NodeJS.Timeout | undefined
 
 	// API
-	readonly apiConfiguration: ProviderSettings
+	apiConfiguration: ProviderSettings
 	api: ApiHandler
 	private static lastGlobalApiRequestTime?: number
 	private autoApprovalHandler: AutoApprovalHandler
@@ -2497,10 +2498,20 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	public async *attemptApiRequest(retryAttempt: number = 0): ApiStream {
-		const state = await this.providerRef.deref()?.getState()
+		const provider = this.providerRef.deref()
+
+		try {
+			await provider?.prepareRoundRobinForRequest?.()
+		} catch (error) {
+			console.error(
+				`[Task#${this.taskId}] Failed to prepare round robin provider:`,
+				error instanceof Error ? error.message : error,
+			)
+		}
+
+		const state = await provider?.getState()
 
 		const {
-			apiConfiguration,
 			autoApprovalEnabled,
 			alwaysApproveResubmit,
 			requestDelaySeconds,
@@ -2509,6 +2520,17 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			autoCondenseContextPercent = 100,
 			profileThresholds = {},
 		} = state ?? {}
+
+		const stateApiConfiguration = state?.apiConfiguration
+
+		if (stateApiConfiguration && !deepEqual(stateApiConfiguration, this.apiConfiguration)) {
+			this.apiConfiguration = stateApiConfiguration
+			this.api = buildApiHandler(stateApiConfiguration)
+		}
+
+		const apiConfiguration = this.apiConfiguration
+
+		this.consecutiveMistakeLimit = apiConfiguration?.consecutiveMistakeLimit ?? DEFAULT_CONSECUTIVE_MISTAKE_LIMIT
 
 		// Get condensing configuration for automatic triggers.
 		const customCondensingPrompt = state?.customCondensingPrompt

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1652,6 +1652,7 @@ export const webviewMessageHandler = async (
 		case "enhancePrompt":
 			if (message.text) {
 				try {
+					await provider.prepareRoundRobinForRequest()
 					const state = await provider.getState()
 
 					const {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -60,6 +60,8 @@ import {
 	Collapsible,
 	CollapsibleTrigger,
 	CollapsibleContent,
+	Input,
+	ToggleSwitch,
 } from "@src/components/ui"
 
 import {
@@ -133,7 +135,7 @@ const ApiOptions = ({
 	setErrorMessage,
 }: ApiOptionsProps) => {
 	const { t } = useAppTranslation()
-	const { organizationAllowList, cloudIsAuthenticated } = useExtensionState()
+	const { organizationAllowList, cloudIsAuthenticated, listApiConfigMeta = [] } = useExtensionState()
 
 	const [customHeaders, setCustomHeaders] = useState<[string, string][]>(() => {
 		const headers = apiConfiguration?.openAiHeaders || {}
@@ -782,6 +784,87 @@ const ApiOptions = ({
 							}
 							onChange={(value) => setApiConfigurationField("consecutiveMistakeLimit", value)}
 						/>
+						<div className="rounded-md border border-vscode-sideBar-border bg-card/40 p-3">
+							<div className="flex items-start justify-between gap-2">
+								<div>
+									<label className="block font-medium">
+										{t("settings:providers.roundRobin.title")}
+									</label>
+									<p className="mt-1 text-xs text-vscode-descriptionForeground">
+										{t("settings:providers.roundRobin.description")}
+									</p>
+								</div>
+								<ToggleSwitch
+									checked={!!apiConfiguration.roundRobinEnabled}
+									onChange={() => {
+										const isEnabled = !apiConfiguration.roundRobinEnabled
+										setApiConfigurationField("roundRobinEnabled", isEnabled)
+
+										if (isEnabled) {
+											if (!apiConfiguration.roundRobinOrder) {
+												const existingOrders =
+													listApiConfigMeta
+														?.map((profile) => profile.roundRobinOrder ?? 0)
+														.filter((order) => order > 0) ?? []
+												const nextOrder =
+													existingOrders.length > 0 ? Math.max(...existingOrders) + 1 : 1
+												setApiConfigurationField("roundRobinOrder", nextOrder)
+											}
+
+											if (!apiConfiguration.roundRobinMessagesPerTurn) {
+												setApiConfigurationField("roundRobinMessagesPerTurn", 1)
+											}
+										}
+									}}
+									aria-label={t("settings:providers.roundRobin.enableLabel")}
+									data-testid="round-robin-toggle"
+								/>
+							</div>
+
+							{apiConfiguration.roundRobinEnabled && (
+								<div className="mt-3 grid gap-3 sm:grid-cols-2">
+									<div>
+										<label className="block font-medium mb-1">
+											{t("settings:providers.roundRobin.orderLabel")}
+										</label>
+										<Input
+											type="number"
+											min={1}
+											value={apiConfiguration.roundRobinOrder ?? ""}
+											onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+												const value = Number.parseInt(event.target.value, 10)
+												setApiConfigurationField(
+													"roundRobinOrder",
+													Number.isNaN(value) ? undefined : Math.max(1, value),
+												)
+											}}
+											data-testid="round-robin-order"
+										/>
+									</div>
+									<div>
+										<label className="block font-medium mb-1">
+											{t("settings:providers.roundRobin.messagesPerTurnLabel")}
+										</label>
+										<Input
+											type="number"
+											min={1}
+											value={apiConfiguration.roundRobinMessagesPerTurn ?? ""}
+											onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+												const value = Number.parseInt(event.target.value, 10)
+												setApiConfigurationField(
+													"roundRobinMessagesPerTurn",
+													Number.isNaN(value) ? undefined : Math.max(1, value),
+												)
+											}}
+											data-testid="round-robin-messages"
+										/>
+										<p className="mt-1 text-xs text-vscode-descriptionForeground">
+											{t("settings:providers.roundRobin.messagesPerTurnHelp")}
+										</p>
+									</div>
+								</div>
+							)}
+						</div>
 						{selectedProvider === "openrouter" &&
 							openRouterModelProviders &&
 							Object.keys(openRouterModelProviders).length > 0 && (

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.provider-filtering.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.provider-filtering.spec.tsx
@@ -80,6 +80,17 @@ vi.mock("@src/components/ui", () => ({
 	CollapsibleContent: ({ children }: any) => <div>{children}</div>,
 	Slider: ({ children, ...props }: any) => <div {...props}>{children}</div>,
 	Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+	ToggleSwitch: ({ checked, onChange, disabled, "aria-label": ariaLabel, "data-testid": dataTestId }: any) => (
+		<button
+			type="button"
+			role="switch"
+			aria-checked={checked}
+			aria-label={ariaLabel}
+			disabled={disabled}
+			data-testid={dataTestId}
+			onClick={() => onChange && onChange()}
+		/>
+	),
 }))
 
 describe("ApiOptions Provider Filtering", () => {

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
@@ -110,6 +110,17 @@ vi.mock("@/components/ui", () => ({
 			</select>
 		</div>
 	),
+	ToggleSwitch: ({ checked, onChange, disabled, "aria-label": ariaLabel, "data-testid": dataTestId }: any) => (
+		<input
+			type="checkbox"
+			role="switch"
+			aria-label={ariaLabel}
+			data-testid={dataTestId || "toggle-switch"}
+			checked={checked}
+			disabled={disabled}
+			onChange={(event) => onChange && onChange(event.target.checked)}
+		/>
+	),
 	// Add Collapsible components
 	Collapsible: ({ children, open }: any) => (
 		<div className="collapsible-mock" data-open={open}>

--- a/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
@@ -150,6 +150,17 @@ vi.mock("@/components/ui", () => ({
 			{children}
 		</div>
 	),
+	ToggleSwitch: ({ checked, onChange, disabled, "aria-label": ariaLabel, "data-testid": dataTestId }: any) => (
+		<button
+			type="button"
+			role="switch"
+			aria-checked={checked}
+			aria-label={ariaLabel}
+			disabled={disabled}
+			data-testid={dataTestId}
+			onClick={() => onChange && onChange()}
+		/>
+	),
 	SelectContent: ({ children }: any) => <div data-testid="select-content">{children}</div>,
 	SelectGroup: ({ children }: any) => <div data-testid="select-group">{children}</div>,
 	SelectItem: ({ children, value }: any) => (

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -235,6 +235,14 @@
 		"searchProviderPlaceholder": "Search providers",
 		"noProviderMatchFound": "No providers found",
 		"noMatchFound": "No matching profiles found",
+		"roundRobin": {
+			"title": "Round robin routing",
+			"description": "Distribute requests across enabled profiles to balance throughput and stay within rate limits.",
+			"enableLabel": "Enable round robin for this profile",
+			"orderLabel": "Rotation order",
+			"messagesPerTurnLabel": "Messages per turn",
+			"messagesPerTurnHelp": "Number of consecutive messages to send before switching to the next profile."
+		},
 		"vscodeLmDescription": " The VS Code Language Model API allows you to run models provided by other VS Code extensions (including but not limited to GitHub Copilot). The easiest way to get started is to install the Copilot and Copilot Chat extensions from the VS Code Marketplace.",
 		"awsCustomArnUse": "Enter a valid Amazon Bedrock ARN for the model you want to use. Format examples:",
 		"awsCustomArnDesc": "Make sure the region in the ARN matches your selected AWS Region above.",


### PR DESCRIPTION
## Summary
- add round robin configuration fields to provider settings metadata
- implement per-mode round robin rotation with task reconfiguration and enhance handler support
- expose UI controls for configuring round robin routing and update tests/translations

## Testing
- pnpm test --filter roo-cline
- pnpm test --filter @roo-code/vscode-webview

------
https://chatgpt.com/codex/tasks/task_e_68ccbcbf1b848320a1b1005436279c75